### PR TITLE
Users: user001 - Adding cookies to remember user

### DIFF
--- a/compat/hmac.go
+++ b/compat/hmac.go
@@ -1,0 +1,41 @@
+package compat
+
+import (
+    "crypto/hmac"
+    "crypto/sha256"
+    "encoding/base64"
+    "hash"
+)
+
+type HMAC struct {
+    hmac    hash.Hash
+}
+
+/**
+ * @brief:  Create new HMAC
+ *
+ * @param:  key - Used to sign data
+ *
+ * @return: HMAC on success
+ **/
+func NewHMAC(key string) HMAC {
+    hmacObj := hmac.New(sha256.New, []byte(key))
+    return HMAC {
+        hmac: hmacObj,
+    }
+}
+
+/**
+ * @brief:  Hash input with secrect key
+ *
+ * @param:  input - String to hash using HMAC
+ *
+ * @return: base64 Encoded URL as string
+ **/
+func (hmacObj HMAC) Hash(input string) string {
+    hmacObj.hmac.Reset()
+    hmacObj.hmac.Write([]byte(input))
+    bytes := hmacObj.hmac.Sum(nil)
+
+    return base64.URLEncoding.EncodeToString(bytes)
+}

--- a/compat/strings.go
+++ b/compat/strings.go
@@ -1,0 +1,51 @@
+package compat
+
+import (
+    "crypto/rand"
+    "encoding/base64"
+)
+
+const RememberTokenBytes = 32
+
+/**
+ * @brief:  Generate n random bytes
+ *
+ * @param:  n - Amount of bytes to generate
+ *
+ * @return: [n]bytes on success, else error
+ **/
+func Bytes(n int) ([]byte, error) {
+    bytes := make([]byte, n)
+    _, err := rand.Read(bytes)
+    if err != nil {
+        return nil, err
+    }
+
+    return bytes, nil
+}
+
+/**
+ * @brief:  Generate slice of size n
+ *
+ * @param:  n - Amount of bytes in slice
+ *
+ * @return: base64 encoded URL on success, else error
+ **/
+func String(n int) (string, error) {
+    bytes, err := Bytes(n)
+    if err != nil {
+        return "", err
+    }
+
+    return base64.URLEncoding.EncodeToString(bytes), nil
+}
+
+/**
+ * @brief:  Generate remember token of
+ *          predetermined byte size
+ *
+ * @return: Remember token on success, else error
+ **/
+func RememberToken() (string, error) {
+    return String(RememberTokenBytes)
+}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ const (
     port    = 5432
     user    = "postgres"
     passwd  = "your-password"
-    dbname  = "database-name"
+    dbname  = "your-dbname"
 )
 
 func main() {
@@ -47,12 +47,15 @@ func main() {
     router := mux.NewRouter()
     router.Handle("/", staticCtrl.Home).Methods("GET")
     router.Handle("/contact", staticCtrl.Contact).Methods("GET")
-    router.HandleFunc("/signup", usersCtrl.NewSignup).Methods("GET")
-    router.HandleFunc("/signup", usersCtrl.CreateSignup).Methods("POST")
+    router.HandleFunc("/signup", usersCtrl.New).Methods("GET")
+    router.HandleFunc("/signup", usersCtrl.Create).Methods("POST")
     router.Handle("/login", usersCtrl.LoginView).Methods("GET")
     router.HandleFunc("/login", usersCtrl.Login).Methods("POST")
     router.Handle("/vault", vaultCtrl.VaultView).Methods("GET")
     router.HandleFunc("/vault", vaultCtrl.Vault).Methods("POST")
+
+    /* Dev testing: display cookies set on the current user */
+    router.HandleFunc("/cookietest", usersCtrl.CookiesTest).Methods("GET")
 
     fmt.Println("Listening on http://localhost:3000")
     fmt.Println(http.ListenAndServe(":3000", router))

--- a/models/types.go
+++ b/models/types.go
@@ -3,11 +3,14 @@ package models
 import (
     "fmt"
 
+    "github.com/loerac/vaultDepot/compat"
+
     "github.com/jinzhu/gorm"
 )
 
 const (
     userPwPepper = "secret-random-string"
+    hmacSecretKey = "secret-hmac-key"
 )
 
 type User struct {
@@ -17,10 +20,13 @@ type User struct {
     Email       string `gorm:"not null;unique_index"`
     Password    string `gorm:"-"`
     PasswordHash string `gorm:"not null"`
+    Remember    string `gorm:"-"`
+    RememberHash string `gorm:"not null;unique_index"`
 }
 
 type UserService struct {
-    db  *gorm.DB
+    db      *gorm.DB
+    hmac    compat.HMAC
 }
 
 type Vault struct {
@@ -36,8 +42,8 @@ type VaultService struct {
 }
 
 func (user *User) String() string {
-    return fmt.Sprintf("User(Firstname='%s', LastName='%s', Email='%s')",
-        user.FirstName, user.LastName, user.Email)
+    return fmt.Sprintf("User(Firstname='%s', LastName='%s', Email='%s', Remember='%s')",
+        user.FirstName, user.LastName, user.Email, user.RememberHash)
 }
 
 func (vault *Vault) String() string {

--- a/views/layouts/navbar.html
+++ b/views/layouts/navbar.html
@@ -10,7 +10,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">GoMan</a>
+            <a class="navbar-brand" href="/">Vault Depot</a>
         </div>
         <div id="navbar" class="navbar-collapse collapes">
             <ul class="nav navbar-nav">

--- a/views/vault/new.html
+++ b/views/vault/new.html
@@ -26,14 +26,14 @@
                id="username" placeholder="Username">
     </div>
     <div class="form-group">
-        <label for="website">Website</label>
+        <label for="website">Application</label>
         <input type="website" name="website" class="form-control"
-               id="website" placeholder="Website">
+               id="website" placeholder="Website, API, etc.">
     </div>
     <div class="form-group">
-        <label for="password">Password</label>
+        <label for="password">Password or Key</label>
         <input type="password" name="password" class="form-control"
-               id="password" placeholder="Password">
+               id="password" placeholder="Password, key, etc.">
     </div>
     <button type="submit" class="btn btn-success">
         Submit


### PR DESCRIPTION
### Description:
When a user creates an account or logins in, there will be a remember token created so next time they open up the site, they won't have to login in.

The method that was created to create the remember token (hash), can be used just the same for storing the passwords in the vault. Can't have passwords be stored in plain text.

### Test:
No test were created but was able to use the "/cookiestest" handle to see that the user does have a remember token every time the user signs-up or logins in